### PR TITLE
add activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
       }
     }
   },
+  "activationHooks": [
+    "language-yaml:grammar-used"
+  ],
   "atomRequirements": [
     "atom-ide-ui"
   ],


### PR DESCRIPTION
 This speeds up loading of Atom, by deferring the loading of ide-yaml until a YAML file is opened or used.